### PR TITLE
changing version to PEP-440 compatible (#1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 
 setup(
     name='gargoyle',
-    version='0.10.9',
+    version='0.10.9+eventbrite',
     author='DISQUS',
     author_email='opensource@disqus.com',
     url='http://github.com/disqus/gargoyle',


### PR DESCRIPTION
To distinguish between wheel built from PyPI version and version patched by Eventbrite, we need to add local identifier to the version
(see https://www.python.org/dev/peps/pep-0440/#local-version-identifiers)