### PR TITLE
[PATCH] Tag upstream's master branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 
 setup(
     name='gargoyle',
-    version='0.11.0',
+    version='0.11.1+eventbrite',
     author='DISQUS',
     author_email='opensource@disqus.com',
     url='https://github.com/disqus/gargoyle',


### PR DESCRIPTION
`gargoyle` has some fixes for Django 1.8, but they haven't been tagged
after the latest 0.11.0 version. The only purpose of this commit is to
be able to tag Gargoyle's upstream `master` branch to get those fixes.